### PR TITLE
Allow important metrics to be sent at different interval

### DIFF
--- a/src/main/java/com/hivemq/extensions/MetricRegistryService.java
+++ b/src/main/java/com/hivemq/extensions/MetricRegistryService.java
@@ -1,0 +1,76 @@
+package com.hivemq.extensions;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.hivemq.extension.sdk.api.services.Services;
+import com.hivemq.extensions.configuration.InfluxDbConfiguration;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MetricRegistryService {
+
+    private MetricRegistry originalRegistry;
+    private MetricRegistry filteredRegistry;
+    private MetricRegistry remainingRegistry;
+
+    public MetricRegistryService(InfluxDbConfiguration config, MetricRegistry originalRegistry) {
+        this.originalRegistry = originalRegistry;
+        this.filteredRegistry = extractFilteredRegistry(config);
+        this.remainingRegistry = (isFilteredRegistryConfigured()) ? extractRemainingRegistry() : originalRegistry;
+    }
+
+    public boolean isFilteredRegistryConfigured() {
+        return filteredRegistry != null && filteredRegistry.getMetrics().size() > 0;
+    }
+
+    public MetricRegistry getFiltered() {
+        return filteredRegistry;
+    }
+
+    public MetricRegistry getRemaining() {
+        return remainingRegistry;
+    }
+
+    /**
+     * Extract a MetricRegistry with all metrics that match the defined filter
+     * @param configuration for this extension
+     * @return new MetricRegistry with filtered metrics
+     */
+    private MetricRegistry extractFilteredRegistry(InfluxDbConfiguration configuration) {
+        String filterStr = configuration.getMetricFilter();
+        if (filterStr == null) return null;
+
+        Set<String> filterSet = Arrays.stream(filterStr.split(";")).map(String::trim).collect(Collectors.toSet());
+
+        Map<String, Metric> originalMetrics = originalRegistry.getMetrics();
+        Map<String, Metric> filteredMetrics = originalMetrics.entrySet().stream()
+              .filter(e -> filterSet.stream().anyMatch(n -> e.getKey().startsWith(n)))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        MetricRegistry ret = new MetricRegistry();
+        for (Map.Entry<String, Metric> e : filteredMetrics.entrySet()) {
+            ret.register(e.getKey(), e.getValue());
+        }
+        return ret;
+    }
+
+    /**
+     * @return new MetricRegistry = originalMetricRegistry - filteredMetricRegistry
+     */
+    private MetricRegistry extractRemainingRegistry() {
+        Map<String, Metric> originalMetrics = originalRegistry.getMetrics();
+        Map<String, Metric> filteredMetrics = filteredRegistry.getMetrics();
+
+        Map<String, Metric> remainingMetrics = originalMetrics.entrySet().stream()
+              .filter(e -> !filteredMetrics.containsKey(e.getKey()))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        MetricRegistry ret = new MetricRegistry();
+        for (Map.Entry<String, Metric> e : remainingMetrics.entrySet()) {
+            ret.register(e.getKey(), e.getValue());
+        }
+        return ret;
+    }
+
+}

--- a/src/main/java/com/hivemq/extensions/configuration/InfluxDbConfiguration.java
+++ b/src/main/java/com/hivemq/extensions/configuration/InfluxDbConfiguration.java
@@ -46,6 +46,7 @@ public class InfluxDbConfiguration extends PropertiesReader {
     private static final String PROTOCOL = "protocol";
     private static final String PROTOCOL_DEFAULT = "http";
     private static final String REPORTING_INTERVAL = "reportingInterval";
+    private static final String FILTERED_REPORTING_INTERVAL = "filteredReportingInterval";
     private static final int REPORTING_INTERVAL_DEFAULT = 1;
     private static final String PREFIX = "prefix";
     private static final String PREFIX_DEFAULT = "";
@@ -56,6 +57,8 @@ public class InfluxDbConfiguration extends PropertiesReader {
     private static final String AUTH = "auth";
     private static final String TAGS = "tags";
     private static final HashMap<String, String> TAGS_DEFAULT = new HashMap<>();
+    private static final String METRICS_FILTER_LIST = "metricsFilterList";
+    private static final String CONSOLE_DEBUG = "consoleDebug";
 
     //InfluxDB Cloud
     private static final String BUCKET = "bucket";
@@ -73,6 +76,8 @@ public class InfluxDbConfiguration extends PropertiesReader {
      */
     public boolean validateConfiguration() {
         int countError = 0;
+
+        if (Boolean.parseBoolean(getProperty(CONSOLE_DEBUG))) return true;
 
         countError += checkMandatoryProperty(HOST);
         countError += checkMandatoryProperty(PORT);
@@ -159,6 +164,10 @@ public class InfluxDbConfiguration extends PropertiesReader {
         return validateIntProperty(REPORTING_INTERVAL, REPORTING_INTERVAL_DEFAULT, false, false);
     }
 
+    public int getFilteredReportingInterval() {
+        return validateIntProperty(FILTERED_REPORTING_INTERVAL, REPORTING_INTERVAL_DEFAULT, false, false);
+    }
+
     public int getConnectTimeout() {
         return validateIntProperty(CONNECT_TIMEOUT, CONNECT_TIMEOUT_DEFAULT, false, false);
     }
@@ -225,6 +234,16 @@ public class InfluxDbConfiguration extends PropertiesReader {
         return "influxdb.properties";
     }
 
+    @Nullable
+    public String getMetricFilter() {
+        return getProperty(METRICS_FILTER_LIST);
+    }
+
+    @Nullable
+    public boolean consoleDebugging() {
+        return Boolean.parseBoolean(getProperty(CONSOLE_DEBUG));
+    }
+
     /**
      * Fetch property with given <b>key</b>. If the fetched {@link String} is <b>null</b> the <b>defaultValue</b> will be returned.
      *
@@ -251,7 +270,8 @@ public class InfluxDbConfiguration extends PropertiesReader {
 
     /**
      * Fetch property with given <b>key</b>.
-     * If the fetched {@link String} value is not <b>null</b> convert the value to an int and check validation constraints if given flags are <b>false</b> before returning the value.
+     * If the fetched {@link String} value is not <b>null</b> convert the value to an int and check validation
+     * constraints if given flags are <b>false</b> before returning the value.
      *
      * @param key             Key of the property
      * @param defaultValue    Default value as fallback, if property has no value

--- a/src/main/resources/influxdb.properties
+++ b/src/main/resources/influxdb.properties
@@ -5,13 +5,22 @@ protocol:http
 auth:
 
 prefix:
-database:hivemq
-
-reportingInterval:1
-connectTimeout:5000
+database: hivemq
 
 tags:host=--NODE-NAME--
 
 # InfluxDB cloud options
 bucket:
 organization:
+
+connectTimeout: 5000
+
+# Filtered metrics can be send at a more frequent interval than the remaining metrics
+filteredReportingInterval: 5
+reportingInterval: 30
+
+# List of metric name prefixes: any metric that starts with one of the prefixes is reported
+metricsFilterList: com.hivemq.messages.outgoing.connack; com.hivemq.messages.outgoing.disconnect
+
+# consoleDebug directs metrics reporting to the console for debugging
+consoleDebug: false

--- a/src/test/java/com/hivemq/extensions/InfluxDbExtensionMainTest.java
+++ b/src/test/java/com/hivemq/extensions/InfluxDbExtensionMainTest.java
@@ -13,7 +13,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
@@ -69,7 +69,7 @@ public class InfluxDbExtensionMainTest {
     public void extensionStart_failed_configuration_file_not_valid() throws IOException {
 
         final List<String> lines = Arrays.asList("host:localhost", "port:-3000");
-        Files.write(file.toPath(), lines, Charset.forName("UTF-8"));
+        Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
 
         final InfluxDbExtensionMain main = new InfluxDbExtensionMain();
         when(extensionStartInput.getExtensionInformation()).thenReturn(extensionInformation);
@@ -86,7 +86,7 @@ public class InfluxDbExtensionMainTest {
     public void extensionStart_failed_configuration_file_valid() throws IOException {
 
         final List<String> lines = Arrays.asList("host:localhost", "port:3000");
-        Files.write(file.toPath(), lines, Charset.forName("UTF-8"));
+        Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
 
         final InfluxDbExtensionMain main = new InfluxDbExtensionMain();
         when(extensionStartInput.getExtensionInformation()).thenReturn(extensionInformation);

--- a/src/test/java/com/hivemq/extensions/MetricsRegistryServiceTest.java
+++ b/src/test/java/com/hivemq/extensions/MetricsRegistryServiceTest.java
@@ -1,0 +1,99 @@
+package com.hivemq.extensions;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.hivemq.extensions.configuration.InfluxDbConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MetricsRegistryServiceTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File root;
+
+    private File file;
+
+    @Before
+    public void set_up() throws IOException {
+        root = folder.getRoot();
+        String fileName = "influxdb.properties";
+        file = folder.newFile(fileName);
+    }
+
+    @Test
+    public void load_with_missing_filter_ok() throws IOException {
+        final List<String> lines = Collections.singletonList("empty:");
+        MetricRegistryService service = new MetricRegistryService(getConfig(lines), mockOriginalMetricRegistry());
+        assertFalse(service.isFilteredRegistryConfigured());
+        assertNull(service.getFiltered());
+        assertEquals(100, service.getRemaining().getMetrics().size());
+    }
+
+    @Test
+    public void load_with_configured_filter_ok() throws IOException {
+        final List<String> lines = Collections.singletonList("metricsFilterList: com.hivemq.messages.99");
+        MetricRegistryService service = new MetricRegistryService(getConfig(lines), mockOriginalMetricRegistry());
+        assertTrue(service.isFilteredRegistryConfigured());
+        assertEquals(1, service.getFiltered().getMetrics().size());
+        assertEquals(99, service.getRemaining().getMetrics().size());
+        assertEquals(mockOriginalMetricRegistry().getMetrics().size(),
+              service.getFiltered().getMetrics().size() + service.getRemaining().getMetrics().size());
+    }
+
+    @Test
+    public void load_with_many_configured_filters_ok() throws IOException {
+        final List<String> lines = Collections.singletonList("metricsFilterList: com.hivemq.messages.1; com.hivemq.messages.2");
+        MetricRegistryService service = new MetricRegistryService(getConfig(lines), mockOriginalMetricRegistry());
+        assertTrue(service.isFilteredRegistryConfigured());
+        assertEquals(22, service.getFiltered().getMetrics().size());
+        assertEquals(78, service.getRemaining().getMetrics().size());
+        assertEquals(mockOriginalMetricRegistry().getMetrics().size(),
+              service.getFiltered().getMetrics().size() + service.getRemaining().getMetrics().size());
+    }
+
+    @Test
+    public void load_with_custom_configured_filters_ok() throws IOException {
+        final List<String> lines = Collections.singletonList(
+              "metricsFilterList: com.hivemq.messages.1; com.hivemq.messages.2; com.hivemq.cache; com.hivemq.msg.rate");
+        MetricRegistry original = mockOriginalMetricRegistry();
+        original.register("com.hivemq.cache.something.else", new Metric(){});
+
+        MetricRegistryService service = new MetricRegistryService(getConfig(lines), original);
+        assertTrue(service.isFilteredRegistryConfigured());
+        assertEquals(23, service.getFiltered().getMetrics().size());
+        assertEquals(78, service.getRemaining().getMetrics().size());
+        assertEquals(original.getMetrics().size(),
+              service.getFiltered().getMetrics().size() + service.getRemaining().getMetrics().size());
+    }
+
+    private MetricRegistry mockOriginalMetricRegistry() {
+        MetricRegistry ret = new MetricRegistry();
+        for (int i = 0; i < 100; i++) {
+            ret.register("com.hivemq.messages." + i, new Metric() { });
+        }
+        return ret;
+    }
+
+    private InfluxDbConfiguration getConfig(List<String> lines) throws IOException {
+        Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
+        final InfluxDbConfiguration ret = new InfluxDbConfiguration(root);
+        ret.readPropertiesFromFile();
+        return ret;
+    }
+}

--- a/src/test/java/com/hivemq/extensions/configuration/PropertiesReaderTest.java
+++ b/src/test/java/com/hivemq/extensions/configuration/PropertiesReaderTest.java
@@ -6,7 +6,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
@@ -20,45 +20,24 @@ public class PropertiesReaderTest {
 
     @Test(expected = NullPointerException.class)
     public void readPropertiesFromFile_file_null() {
-        new PropertiesReader(null) {
-            @Override
-            public String getFilename() {
-                return "test";
-            }
-        };
+        getPropertyReader(null);
     }
-
 
     @Test
     public void readPropertiesFromFile_file_does_not_exist() {
-
         final File root = folder.getRoot();
-
-        final PropertiesReader propertiesReader = new PropertiesReader(root) {
-            @Override
-            public String getFilename() {
-                return "test";
-            }
-        };
+        final PropertiesReader propertiesReader = getPropertyReader(root);
 
         final boolean fileExists = propertiesReader.readPropertiesFromFile();
-
         assertFalse(fileExists);
     }
 
     @Test
     public void readPropertiesFromFile_file_does_exist() throws IOException {
         final File root = folder.getRoot();
-
         folder.newFile("test");
 
-        final PropertiesReader propertiesReader = new PropertiesReader(root) {
-            @Override
-            public String getFilename() {
-                return "test";
-            }
-        };
-
+        final PropertiesReader propertiesReader = getPropertyReader(root);
         final boolean fileExists = propertiesReader.readPropertiesFromFile();
 
         assertTrue(fileExists);
@@ -66,19 +45,8 @@ public class PropertiesReaderTest {
 
     @Test(expected = NullPointerException.class)
     public void getProperty_key_null() throws IOException {
-        final File root = folder.getRoot();
-
-        final File file = folder.newFile("test");
-
         final List<String> lines = Collections.singletonList("key:value");
-        Files.write(file.toPath(), lines, Charset.forName("UTF-8"));
-
-        final PropertiesReader propertiesReader = new PropertiesReader(root) {
-            @Override
-            public String getFilename() {
-                return "test";
-            }
-        };
+        final PropertiesReader propertiesReader = getPropertyReaderFromFile(lines);
 
         final boolean fileExists = propertiesReader.readPropertiesFromFile();
         assertTrue(fileExists);
@@ -91,19 +59,8 @@ public class PropertiesReaderTest {
 
     @Test
     public void getProperty_key_doesnt_exist() throws IOException {
-        final File root = folder.getRoot();
-
-        final File file = folder.newFile("test");
-
         final List<String> lines = Collections.singletonList("key:value");
-        Files.write(file.toPath(), lines, Charset.forName("UTF-8"));
-
-        final PropertiesReader propertiesReader = new PropertiesReader(root) {
-            @Override
-            public String getFilename() {
-                return "test";
-            }
-        };
+        final PropertiesReader propertiesReader = getPropertyReaderFromFile(lines);
 
         final boolean fileExists = propertiesReader.readPropertiesFromFile();
         assertTrue(fileExists);
@@ -117,19 +74,8 @@ public class PropertiesReaderTest {
 
     @Test
     public void getProperty_key_exists() throws IOException {
-        final File root = folder.getRoot();
-
-        final File file = folder.newFile("test");
-
         final List<String> lines = Collections.singletonList("key:value");
-        Files.write(file.toPath(), lines, Charset.forName("UTF-8"));
-
-        final PropertiesReader propertiesReader = new PropertiesReader(root) {
-            @Override
-            public String getFilename() {
-                return "test";
-            }
-        };
+        final PropertiesReader propertiesReader = getPropertyReaderFromFile(lines);
 
         final boolean fileExists = propertiesReader.readPropertiesFromFile();
         assertTrue(fileExists);
@@ -140,22 +86,29 @@ public class PropertiesReaderTest {
 
     @Test
     public void getProperty_before_loading_properties() throws IOException {
-        final File root = folder.getRoot();
-
-        final File file = folder.newFile("test");
-
         final List<String> lines = Collections.singletonList("key:value");
-        Files.write(file.toPath(), lines, Charset.forName("UTF-8"));
-
-        final PropertiesReader propertiesReader = new PropertiesReader(root) {
-            @Override
-            public String getFilename() {
-                return "test";
-            }
-        };
+        final PropertiesReader propertiesReader = getPropertyReaderFromFile(lines);
 
         final String property = propertiesReader.getProperty("key");
         assertNull(property);
     }
 
+    private PropertiesReader getPropertyReaderFromFile(List<String> lines) throws IOException {
+        writeFile(lines);
+        return getPropertyReader(folder.getRoot());
+    }
+
+    private void writeFile(List<String> lines) throws IOException {
+        final File file = folder.newFile("test");
+        Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
+    }
+
+    private PropertiesReader getPropertyReader(File configFilePath) {
+        return new PropertiesReader(configFilePath) {
+            @Override
+            public String getFilename() {
+                return "test";
+            }
+        };
+    }
 }


### PR DESCRIPTION
**Why**:
Allow a user defined set of filters to determine which metrics are sent at a different interval from the remaining metrics. 
**What**:
- added config param "metricsFilterList", metrics that match an entry (startsWith) from this list are sent every "filteredReportingInterval"
- the remainingMetrics are sent every "reportingInterval"
- added config param "consoleDebug", if set to "true" metrics are reported to console for debugging

**ReleaseNotes**: 
- Configure a list of metricFilters that collect matching Metrics to be sent at a different interval than the remaining metrics. The list entries are delimited with a semi-colon. 